### PR TITLE
Make MNIST example run out-of-the-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains binary models, based on original mxnet architectures and others.
 Note, that not all models and changes are documented completely.
 
-Examples for hyperparameters are documented in the [Wiki](https://github.com/hpi-xnor/BMXNet-v2-wiki/blob/master/hyperparameters.md).
+Examples for hyperparameters are documented in the [Wiki](https://github.com/hpi-xnor/BMXNet-v2-wiki).
 
 ## Datasets
 

--- a/mnist/mnist.py
+++ b/mnist/mnist.py
@@ -26,7 +26,6 @@ import numpy as np
 import mxnet as mx
 from mxnet import gluon, autograd
 from mxnet.gluon import nn
-from binary import BDense
 
 # Parse CLI arguments
 
@@ -52,16 +51,16 @@ opt = parser.parse_args()
 net = nn.HybridSequential()
 with net.name_scope():
     if opt.bits == 1:
-        net.add(BDense(128))
-        net.add(BDense(64))
-        net.add(BDense(10))
+        net.add(nn.QDense(128, bits=opt.bits))
+        net.add(nn.QDense(64, bits=opt.bits))
+        net.add(nn.QDense(10, bits=opt.bits))
     elif opt.bits < 32:
         raise RuntimeError("Quantization not yet supported")
     else:
         net.add(nn.Dense(128, activation='relu'))
         net.add(nn.Dense(64, activation='relu'))
         net.add(nn.Dense(10))
-# net.hybridize()
+net.hybridize()
 
 # data
 


### PR DESCRIPTION
I renamed the ``BDense`` layer by the ``nn.QDense`` layer. It looks like this change in the BMXNet was forgotten here.

Further, I changed the link to point to the [BMXNet-v2-wiki](https://github.com/hpi-xnor/BMXNet-v2-wiki) instead of pointing to the hyperparameters page directly, because on the [hyperparameters page](https://github.com/hpi-xnor/BMXNet-v2-wiki/blob/master/hyperparameters.md) the link to the experiments (see bottom) does not work. 